### PR TITLE
invoke.shをAWS CLI ver2に対応

### DIFF
--- a/sample-apps/blank-java/4-invoke.sh
+++ b/sample-apps/blank-java/4-invoke.sh
@@ -3,8 +3,8 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-java --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
-  cat out.json
+  aws lambda invoke --cli-binary-format raw-in-base64-out --function-name $FUNCTION --payload file://event.json out.json
+  cat out.json | jq -r
   echo ""
   sleep 2
 done


### PR DESCRIPTION
# aws lambda invokeの起動オプションを変更
- AWS CLI ver2では、入力パラメータがbase64かどうかのチェックが入るようになった模様
- `--cli-binary-format raw-in-base64-out` でチェックを無効化する処理を追加
参考 : https://qiita.com/marqs/items/793b72bbd9557441fbf4
